### PR TITLE
added overflow: hidden to .stop-container

### DIFF
--- a/src/scss/layout/_stop-page.scss
+++ b/src/scss/layout/_stop-page.scss
@@ -4,6 +4,7 @@
 
 .stop-container {
   font-family: "Nunito", sans-serif;
+  overflow: hidden;
   font-weight: 300;
   background: #111d2b;
   display: flex;


### PR DESCRIPTION
This prevents a glitch where a scroll bar would momentarily appear at the start of each breathing cycle